### PR TITLE
Elements scaled to full page (page fitting)

### DIFF
--- a/carp.css
+++ b/carp.css
@@ -6,6 +6,8 @@ html {
 body {
     height: 100%;
     width: 100%;
+    margin: 0;
+    padding: 0;
      
     background-color: white;
 }

--- a/carp.css
+++ b/carp.css
@@ -1,10 +1,18 @@
+html {
+    height: 100%;
+    width: 100%;
+}
+
 body {
+    height: 100%;
+    width: 100%;
+     
     background-color: white;
 }
 
 .head {
     background-color: green;
-   	border-style: solid;
+    border-style: solid;
     border-width: 5%;
     text-align: center;
     margin-bottom: 2%;


### PR DESCRIPTION
# Two commits
First:
- Set the page to 100% of the screen

Second:
- Movement because there was a built-in padding/margin on the body. This was removed, and the movement issue was fixed.

(I also instinctively fixed an accidentally added space for a statement in the head class.)